### PR TITLE
Replace old Hypixel API with the official one

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ repositories {
         name = "CodeMC"
         url = uri("https://repo.codemc.org/repository/maven-public/")
     }
+    maven { url = uri("https://repo.hypixel.net/repository/Hypixel/") }
     mavenCentral()
     maven { url = uri("https://jitpack.io") }
 }
@@ -28,7 +29,7 @@ dependencies {
     compileOnly("io.papermc.paper:paper-api:1.19-R0.1-SNAPSHOT")
     compileOnly("de.maxhenkel.voicechat:voicechat-api:2.2.19")
     compileOnly("com.discordsrv:discordsrv:1.25.1")
-    implementation("com.github.ReflxctionDev:SimpleHypixelAPI:1.0.9-BETA")
+    implementation("net.hypixel:hypixel-api-transport-apache:4.2")
     implementation("org.reflections:reflections:0.10.2")
     implementation("cloud.commandframework:cloud-paper:1.7.0")
     implementation("cloud.commandframework:cloud-annotations:1.7.0")

--- a/src/main/kotlin/moe/neat/tbdutils/util/Hypixel.kt
+++ b/src/main/kotlin/moe/neat/tbdutils/util/Hypixel.kt
@@ -1,13 +1,13 @@
 package moe.neat.tbdutils.util
 
+import net.hypixel.api.HypixelAPI
+import net.hypixel.api.apache.ApacheHttpClient
+import net.hypixel.api.reply.PlayerReply
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.minimessage.MiniMessage
 import org.bukkit.entity.Player
 import java.util.*
-import net.hypixel.api.HypixelAPI
-import net.hypixel.api.apache.ApacheHttpClient
-import net.hypixel.api.reply.PlayerReply
 
 /**
  * Utilities relating to Hypixel using the [HypixelAPI]
@@ -19,12 +19,7 @@ class Hypixel(apiKey: String) {
     private val playerCache = mutableMapOf<UUID, PlayerReply.Player>()
     private val mm = MiniMessage.miniMessage()
 
-    private fun getPlayer(player: UUID): PlayerReply.Player {
-        if (playerCache[player] == null) {
-            playerCache[player] = api.getPlayerByUuid(player).get().player
-        }
-        return playerCache[player]!!
-    }
+    private fun getPlayer(player: UUID) = playerCache.getOrPut(player) { api.getPlayerByUuid(player).get().player }
 
     /**
      * Get the formatted display name of a player on Hypixel.

--- a/src/main/kotlin/moe/neat/tbdutils/util/Hypixel.kt
+++ b/src/main/kotlin/moe/neat/tbdutils/util/Hypixel.kt
@@ -1,13 +1,13 @@
 package moe.neat.tbdutils.util
 
-import io.github.reflxction.hypixelapi.HypixelAPI
-import io.github.reflxction.hypixelapi.player.HypixelPlayer
-import io.github.reflxction.hypixelapi.player.PlayerRank
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.minimessage.MiniMessage
 import org.bukkit.entity.Player
 import java.util.*
+import net.hypixel.api.HypixelAPI
+import net.hypixel.api.apache.ApacheHttpClient
+import net.hypixel.api.reply.PlayerReply
 
 /**
  * Utilities relating to Hypixel using the [HypixelAPI]
@@ -15,13 +15,13 @@ import java.util.*
  * @param apiKey Apikey obtained with /api on Hypixel
  */
 class Hypixel(apiKey: String) {
-    private val api = HypixelAPI.create(apiKey)
-    private val playerCache = mutableMapOf<UUID, HypixelPlayer>()
+    private val api = HypixelAPI(ApacheHttpClient(UUID.fromString(apiKey)))
+    private val playerCache = mutableMapOf<UUID, PlayerReply.Player>()
     private val mm = MiniMessage.miniMessage()
 
-    private fun getPlayer(player: UUID): HypixelPlayer {
+    private fun getPlayer(player: UUID): PlayerReply.Player {
         if (playerCache[player] == null) {
-            playerCache[player] = api.getPlayer(player)
+            playerCache[player] = api.getPlayerByUuid(player).get().player
         }
         return playerCache[player]!!
     }
@@ -31,17 +31,30 @@ class Hypixel(apiKey: String) {
      *
      * @param player The player for which to fetch the display name
      * @return Hypixel styled component
+     *
+     * @see <a href="https://github.com/HypixelDev/PublicAPI/wiki/Common-Questions#how-do-i-get-a-players-rank-prefix">Available Ranks on Hypixel</a>
      */
     fun getHypixelDisplayName(player: Player): Component {
         val defaultComponent = Component.text(player.name).color(NamedTextColor.GRAY)
-        val rank = getPlayer(player.uniqueId).newPackageRank ?: return defaultComponent
+        val apiPlayer = getPlayer(player.uniqueId)
 
-        return when (rank) {
-            PlayerRank.DEFAULT -> defaultComponent
-            PlayerRank.VIP -> Component.text("[VIP] ${player.name}").color(NamedTextColor.GREEN)
-            PlayerRank.VIP_PLUS -> mm.deserialize("<green>[VIP<gold>+</gold>] ${player.name}</green>")
-            PlayerRank.MVP -> Component.text("[MVP] ${player.name}").color(NamedTextColor.AQUA)
-            PlayerRank.MVP_PLUS -> mm.deserialize("<aqua>[MVP<red>+</red>] ${player.name}</aqua>")
+        return when (apiPlayer.highestRank) {
+            "VIP" -> Component.text("[VIP] ${player.name}").color(NamedTextColor.GREEN)
+            "VIP_PLUS" -> mm.deserialize("<green>[VIP<gold>+</gold>] ${player.name}</green>")
+            "MVP" -> Component.text("[MVP] ${player.name}").color(NamedTextColor.AQUA)
+            "MVP_PLUS" -> {
+                val plusColor = apiPlayer.selectedPlusColor
+                mm.deserialize("<aqua>[MVP<${plusColor}>+</${plusColor}>] ${player.name}</aqua>")
+            }
+            "SUPERSTAR" -> {
+                val tagColor = apiPlayer.superstarTagColor
+                val plusColor = apiPlayer.selectedPlusColor
+                mm.deserialize("<${tagColor}>[MVP<${plusColor}>++</${plusColor}>] ${player.name}</${tagColor}>")
+            }
+            "YOUTUBE" -> mm.deserialize("<red>[</red><white>YOUTUBE</white><red>] ${player.name}</red>")
+            "GAME_MASTER" -> Component.text("[GM] ${player.name}").color(NamedTextColor.DARK_GREEN)
+            "ADMIN" -> Component.text("[ADMIN] ${player.name}").color(NamedTextColor.RED)
+            else -> defaultComponent
         }
     }
 }


### PR DESCRIPTION
Replaces the outdated/archived [SimpleHypixelAPI](https://github.com/Revxrsal/SimpleHypixelAPI) with the official [HypixelAPI](https://github.com/HypixelDev/PublicAPI).

Also adds support for colored "+" for MVP+ and adds full support for MVP++, YouTuber, Game Master and Admin rank.

Tested with Paper 1.19-29:

![image](https://user-images.githubusercontent.com/12937331/174504240-737ebb7f-8ee8-4641-a23e-17c9954ff228.png)
![image](https://user-images.githubusercontent.com/12937331/174504245-4f00eae0-121a-45cd-97a6-cc9233d09ca0.png)
