### PR TITLE
Added setnick command

### DIFF
--- a/src/main/kotlin/moe/neat/tbdutils/commands/SetNick.kt
+++ b/src/main/kotlin/moe/neat/tbdutils/commands/SetNick.kt
@@ -1,0 +1,35 @@
+package moe.neat.tbdutils.commands
+
+import cloud.commandframework.annotations.*
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
+import org.bukkit.Bukkit
+import org.bukkit.entity.Player
+
+class SetNick : BaseCommand {
+
+    @CommandMethod("setnick <player> <nick>")
+    @CommandDescription("Allows nick modification.")
+    @CommandPermission("tbdutils.command.setnick")
+    fun nick(sender : Player, @Argument("player") player : Player, @Argument("nick") nick : String) {
+        try {
+            if (nick.length > 16) {
+                sender.sendMessage(Component.text("Oh nonononono... bad! That name is too long.", NamedTextColor.RED))
+                return
+            }
+
+            val previousName = player.name
+            sender.sendMessage(Component.text("Attempting to change nick from $previousName to ${nick}...").color(NamedTextColor.GRAY))
+            setNick(player, nick)
+            sender.sendMessage(Component.text("Successfully changed nick from $previousName to ${nick}.").color(NamedTextColor.GREEN))
+        } catch(e : Exception) {
+            sender.sendMessage(Component.text("An error occurred when attempting to change a player's nick.", NamedTextColor.RED))
+            e.printStackTrace()
+        }
+    }
+
+    private fun setNick(player : Player, nick : String) {
+        player.playerProfile = Bukkit.createProfileExact(player.uniqueId, nick)
+        player.playerListName(Component.text(nick))
+    }
+}


### PR DESCRIPTION
This PR adds a new command called `setnick`.

- It changes nickname of the specified player while they're on the server.
- To remove the custom nickname, you can use the command again or have the affected player rejoin the server or restart the server.